### PR TITLE
ヘッダーの調整

### DIFF
--- a/first/css/style.css
+++ b/first/css/style.css
@@ -4,21 +4,19 @@ html,body {
     width: 100%;
 }
 
-.container{
-    width: 100%;
-    /* max-width: 1200px; */
-}
-
 .header{
     display: flex;
-    justify-content: center;
-    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 auto;
+    max-width: 960px;
+    padding: 0 4%;
 }
 
 .header__logo{
     width: 120px;
     height: 40px;
-    padding: 10px 581px 10px 230px;
+    /* padding: 10px 581px 10px 230px; */
 }
 
 .header__nav-list{

--- a/first/html/index.html
+++ b/first/html/index.html
@@ -8,62 +8,60 @@
     <title>test</title>
 </head>
 <body>
-  <div class="container">
-    <header class="header">
-      <h1>
-        <img class="header__logo" src="../img/logo.svg" alt="logo" />
-      </h1>
-      <nav class="header__nav">
-        <ul class="header__nav-list">
-          <li class="header__nav-item">About</li>
-          <li class="header__nav-item">Bicycle</li>
-        </ul>
-      </nav>
-    </header>
-      <main>
-        <div>
-          <img class="main__top-img" src="../img/mainvisual.jpg" alt="top"/>
-        </div>
-        <section>
-          <h2 class="main__section-h2">About</h2>
-          <div class="main__section-content">
-            <img class="main__section-img" src="../img/about.jpg" alt="about">
-            <div>
-              <h3 class="main__section-h3">KAKERU MIYAICHI</h3>
-              <p class="main__section-p">テキストテキストテキストテキストテキストテキストテキスト テキストテキストテキストテキストテキストテキストテキスト テキストテキストテキストテキストテキストテキストテキスト</p>
-            </div>
-          </div>
-        </section>
-        <section>
-          <h2 class="main__section-h2">Bicycle</h2>
-          <ul class="main__section-ul">
-            <li>
-              <img class="main__section-item" src="../img/bicycle1.jpg" alt="bicycle1">
-              <div>
-                <h3 class="main__section-title">タイトルタイトル</h3>
-                <p class="main__section-item-p">テキストテキストテキスト</p>
-              </div>
-            </li>
-            <li>
-              <img class="main__section-item" src="../img/bicycle2.jpg" alt="bicycle2">
-              <div class="main_section-div">
-                <h3 class="main__section-title">タイトルタイトル</h3>
-                <p class="main__section-item-p">テキストテキストテキスト</p>
-              </div>
-            </li>
-            <li>
-              <img class="main__section-item" src="../img/bicycle3.jpg" alt="bicycle3">
-              <div>
-                <h3 class="main__section-title">タイトルタイトル</h3>
-                <p class="main__section-item-p">テキストテキストテキスト</p>
-              </div>
-            </li>
-          </ul>
-        </section> 
-      </main>
-      <footer class="footer">
-          <p>&copy; 2020 Profile</p>
-      </footer>
+  <header class="header">
+    <h1>
+      <img class="header__logo" src="../img/logo.svg" alt="logo" />
+    </h1>
+    <nav class="header__nav">
+      <ul class="header__nav-list">
+        <li class="header__nav-item">About</li>
+        <li class="header__nav-item">Bicycle</li>
+      </ul>
+    </nav>
+  </header>
+  <main>
+    <div>
+      <img class="main__top-img" src="../img/mainvisual.jpg" alt="top"/>
     </div>
+    <section>
+      <h2 class="main__section-h2">About</h2>
+      <div class="main__section-content">
+        <img class="main__section-img" src="../img/about.jpg" alt="about">
+        <div>
+          <h3 class="main__section-h3">KAKERU MIYAICHI</h3>
+          <p class="main__section-p">テキストテキストテキストテキストテキストテキストテキスト テキストテキストテキストテキストテキストテキストテキスト テキストテキストテキストテキストテキストテキストテキスト</p>
+        </div>
+      </div>
+    </section>
+    <section>
+      <h2 class="main__section-h2">Bicycle</h2>
+      <ul class="main__section-ul">
+        <li>
+          <img class="main__section-item" src="../img/bicycle1.jpg" alt="bicycle1">
+          <div>
+            <h3 class="main__section-title">タイトルタイトル</h3>
+            <p class="main__section-item-p">テキストテキストテキスト</p>
+          </div>
+        </li>
+        <li>
+          <img class="main__section-item" src="../img/bicycle2.jpg" alt="bicycle2">
+          <div class="main_section-div">
+            <h3 class="main__section-title">タイトルタイトル</h3>
+            <p class="main__section-item-p">テキストテキストテキスト</p>
+          </div>
+        </li>
+        <li>
+          <img class="main__section-item" src="../img/bicycle3.jpg" alt="bicycle3">
+          <div>
+            <h3 class="main__section-title">タイトルタイトル</h3>
+            <p class="main__section-item-p">テキストテキストテキスト</p>
+          </div>
+        </li>
+      </ul>
+    </section> 
+  </main>
+  <footer class="footer">
+      <p>&copy; 2020 Profile</p>
+  </footer>
 </body>
 </html>


### PR DESCRIPTION

・header__logoにpaddingが沢山入っていたので、ヘッダー部分が見切れてしまうのかと思います。
→　pxより%使えるところは使っていった方がレスポンシブ対応もしやすいです。

【中央に持ってくる】
中央に持ってくる方法は色々とあります。
今回使ったのが、
・左右中央にする
　margin: 0 auto;
・上下中央
　display: flex;
    justify-content: space-between;
    align-items: center;
などもよく使います。
・div containerは、bodyと役割が変わらなかったので、不要なコードとして削除しました。

![image](https://github.com/nuko148/test_web/assets/68770062/626e24fd-fda5-478b-a16a-d1be0a37901e)
